### PR TITLE
Transform changes

### DIFF
--- a/docs/usage/changelog.rst
+++ b/docs/usage/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 0.6.2 - TBD
   * Updated lifx-photons-core
+  * Added ``transform_options`` to the ``transform`` comannd. 
 
 0.6.1 - 16 Februrary 2020
   * Updated lifx-photons-core

--- a/photons_interactor/commander/commands/control.py
+++ b/photons_interactor/commander/commands/control.py
@@ -92,9 +92,26 @@ class TransformCommand(store.Command):
           """,
     )
 
+    transform_options = dictobj.Field(
+        sb.dictionary_spec(),
+        help="""
+            A dictionay of options that modify the way the tranform
+            is performed:
+
+            keep_brightness
+                Ignore brightness options in the request
+
+            transition_color
+                If the light is off and we power on, setting this to True will mean the
+                color of the light is not set to the new color before we make it appear
+                to be on. This defaults to False, which means it will appear to turn on
+                with the new color
+            """,
+    )
+
     async def execute(self):
         fltr = chp.filter_from_matcher(self.matcher, self.refresh)
-        msg = Transformer.using(self.transform)
+        msg = Transformer.using(self.transform, **self.transform_options)
         script = self.target.script(msg)
         return await chp.run(
             script, fltr, self.finder, add_replies=False, message_timeout=self.timeout

--- a/photons_interactor/commander/default_fields.py
+++ b/photons_interactor/commander/default_fields.py
@@ -3,7 +3,7 @@ from delfick_project.norms import dictobj, sb
 refresh_field = dictobj.NullableField(
     sb.boolean,
     help="""
-        Whether to refresh our idea of what is on the network"
+        Whether to refresh our idea of what is on the network
 
         If this is False then we will use the cached notion of what's on the network.
       """,


### PR DESCRIPTION
This enables a transform to transition the color along with the brightness if the power is turned on at the beginning of the transform. Useful for transitioning from a night light to bright white.

Also fixed a typo I noticed along the way, at no extra charge. :)

Requires https://github.com/delfick/photons-core/pull/8